### PR TITLE
fix: Compute block number to attest to using uint256

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,9 @@ require (
 	github.com/NethermindEth/juno v0.12.2
 	github.com/NethermindEth/starknet.go v0.8.0-beta.2
 	github.com/golang/mock v1.6.0
+	github.com/holiman/uint256 v1.3.2
+	github.com/sourcegraph/conc v0.3.0
+	github.com/stretchr/testify v1.10.0
 	lukechampine.com/uint128 v1.3.0
 )
 
@@ -30,7 +33,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
-	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
@@ -44,9 +46,7 @@ require (
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
-	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/utils"
 	"github.com/NethermindEth/starknet.go/rpc"
+	"github.com/holiman/uint256"
 	"github.com/sourcegraph/conc"
 )
 
@@ -137,10 +138,15 @@ func computeBlockNumberToAttestTo(account Accounter, attestationInfo Attestation
 		&accountAddress,
 	)
 
-	// todo: use Uint256
-	blockOffset := hash % (attestationInfo.EpochLen - attestationWindow)
+	hashUint256, err := uint256.FromHex(hash.String())
+	if err != nil {
+		return BlockNumber(0)
+	}
 
-	return BlockNumber(startingBlock + blockOffset)
+	var blockOffsetUint256 *uint256.Int
+	blockOffsetUint256 = blockOffsetUint256.Mod(hashUint256, uint256.NewInt(attestationInfo.EpochLen-attestationWindow))
+
+	return BlockNumber(startingBlock + blockOffsetUint256.Uint64())
 }
 
 func SchedulePendingAttestations(


### PR DESCRIPTION
I used the Uint256 library.

We could have also used big.Int library, it has the Mod() method.
I wonder if it wouldn't have been better than uint256 ? Maybe 1 less dependency (uint256) to add