### PR TITLE
feat: Local/external signer choice

### DIFF
--- a/attest.go
+++ b/attest.go
@@ -24,16 +24,23 @@ func Attest(config Config) error {
 		return err
 	}
 
-	validatorAccount, err := NewValidatorAccount(provider, logger, &config.AccountData)
-	if err != nil {
-		return err
+	var account Accounter
+	if config.useLocalSigner {
+		validatorAccount, err := NewValidatorAccount(provider, logger, &config.AccountData)
+		if err != nil {
+			return err
+		}
+		account = &validatorAccount
+	} else {
+		externalSigner := newExternalSigner(provider, config.AccountData.OperationalAddress, config.ExternalSignerUrl)
+		account = &externalSigner
 	}
 
-	dispatcher := NewEventDispatcher[*ValidatorAccount, *utils.ZapLogger]()
+	dispatcher := NewEventDispatcher[Accounter, *utils.ZapLogger]()
 
 	wg := conc.NewWaitGroup()
 	defer wg.Wait()
-	wg.Go(func() { dispatcher.Dispatch(&validatorAccount, logger) })
+	wg.Go(func() { dispatcher.Dispatch(account, logger) })
 
 	// Subscribe to the block headers
 	wsProvider, headersFeed, err := BlockHeaderSubscription(config.WsProviderUrl, logger)
@@ -43,7 +50,7 @@ func Attest(config Config) error {
 	defer wsProvider.Close()
 	defer close(headersFeed)
 
-	if err := ProcessBlockHeaders(headersFeed, &validatorAccount, logger, &dispatcher); err != nil {
+	if err := ProcessBlockHeaders(headersFeed, account, logger, &dispatcher); err != nil {
 		return err
 	}
 	// I'd also like to check the balance of the address from time to time to verify

--- a/attest.go
+++ b/attest.go
@@ -32,7 +32,10 @@ func Attest(config Config) error {
 		}
 		account = &validatorAccount
 	} else {
-		externalSigner := newExternalSigner(provider, config.AccountData.OperationalAddress, config.ExternalSignerUrl)
+		externalSigner, err := newExternalSigner(provider, config.AccountData.OperationalAddress, config.ExternalSignerUrl)
+		if err != nil {
+			return err
+		}
 		account = &externalSigner
 	}
 

--- a/attest.go
+++ b/attest.go
@@ -32,7 +32,7 @@ func Attest(config Config) error {
 		}
 		account = &validatorAccount
 	} else {
-		externalSigner, err := newExternalSigner(provider, config.AccountData.OperationalAddress, config.ExternalSignerUrl)
+		externalSigner, err := NewExternalSigner(provider, config.AccountData.OperationalAddress, config.ExternalSignerUrl)
 		if err != nil {
 			return err
 		}

--- a/errors.go
+++ b/errors.go
@@ -9,3 +9,11 @@ func entrypointInternalError(entrypointName string, err error) error {
 func entrypointResponseError(entrypointName string) error {
 	return errors.New("Invalid response from entrypoint `" + entrypointName + "`")
 }
+
+func missingConfigGeneralField(missingFieldName string) error {
+	return errors.New("you must specify the " + missingFieldName + " field in the config.json")
+}
+
+func missingConfigSignerField(missingFieldName string, signerFlag string) error {
+	return errors.New("you must specify the " + missingFieldName + " field in the config.json when using " + signerFlag + " flag")
+}

--- a/example-signer/external_signer.go
+++ b/example-signer/external_signer.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/big"
+	"net/http"
+	"os"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/starknet.go/account"
+	"github.com/NethermindEth/starknet.go/curve"
+	"github.com/cockroachdb/errors"
+)
+
+type SignRequest struct {
+	Hash felt.Felt `json:"hash"`
+}
+
+type SignResponse struct {
+	Signature []*felt.Felt `json:"signature"`
+}
+
+type Signer struct {
+	publicKey *big.Int
+	keyStore  *account.MemKeystore
+}
+
+func loadEnv() string {
+	// err := godotenv.Load(".env")
+	// if err != nil {
+	// 	panic(errors.Join(errors.New("error loading '.env' file"), err))
+	// }
+
+	signerKey := os.Getenv("PRIVATE_KEY")
+	fmt.Println("signerKey", signerKey)
+	if signerKey == "" {
+		panic("Failed to load PRIVATE_KEY, empty string")
+	}
+
+	return signerKey
+}
+
+func newSigner(privateKey string) (Signer, error) {
+	privKey, ok := new(big.Int).SetString(privateKey, 0)
+	if !ok {
+		return Signer{}, errors.Errorf("Cannot turn private key %s into a big int", privateKey)
+	}
+
+	publicKey, _, err := curve.Curve.PrivateToPoint(privKey)
+	if err != nil {
+		return Signer{}, errors.New("Cannot derive public key from private key")
+	}
+
+	ks := account.SetNewMemKeystore(publicKey.String(), privKey)
+
+	return Signer{keyStore: ks, publicKey: publicKey}, nil
+}
+
+func (s *Signer) sign(msg *felt.Felt) ([]*felt.Felt, error) {
+	msgBig := msg.BigInt(new(big.Int))
+
+	s1, s2, err := s.keyStore.Sign(context.Background(), s.publicKey.String(), msgBig)
+	if err != nil {
+		return nil, err
+	}
+
+	s1Felt := new(felt.Felt).SetBigInt(s1)
+	s2Felt := new(felt.Felt).SetBigInt(s2)
+
+	return []*felt.Felt{s1Felt, s2Felt}, nil
+}
+
+func signHandler(w http.ResponseWriter, r *http.Request, signer *Signer) {
+	var req SignRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	signature, err := signer.sign(&req.Hash)
+	if err != nil {
+		http.Error(w, "Failed to sign hash: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp := SignResponse{
+		Signature: signature,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func main() {
+	signerKey := loadEnv()
+	signer, err := newSigner(signerKey)
+	if err != nil {
+		panic(err)
+	}
+
+	http.HandleFunc("/sign_hash", func(w http.ResponseWriter, r *http.Request) {
+		signHandler(w, r, &signer)
+	})
+
+	log.Println("🚀 Server running at http://localhost:8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/example-signer/remote_signer.go
+++ b/example-signer/remote_signer.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"math/big"
 	"net/http"
@@ -35,7 +34,6 @@ func loadEnv() string {
 	// }
 
 	signerKey := os.Getenv("PRIVATE_KEY")
-	fmt.Println("signerKey", signerKey)
 	if signerKey == "" {
 		panic("Failed to load PRIVATE_KEY, empty string")
 	}

--- a/example-signer/remote_signer.go
+++ b/example-signer/remote_signer.go
@@ -86,9 +86,7 @@ func signHandler(w http.ResponseWriter, r *http.Request, signer *Signer) {
 		return
 	}
 
-	resp := SignResponse{
-		Signature: signature,
-	}
+	resp := SignResponse{Signature: signature}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)

--- a/external_signer.go
+++ b/external_signer.go
@@ -19,7 +19,7 @@ type SignResponse struct {
 	Signature []*felt.Felt `json:"signature"`
 }
 
-func signTxHash(hash *felt.Felt, externalSignerUrl string) (*SignResponse, error) {
+func SignTxHash(hash *felt.Felt, externalSignerUrl string) (*SignResponse, error) {
 	// Create request body
 	reqBody := SignRequest{Hash: hash.String()}
 	jsonData, err := json.Marshal(reqBody)

--- a/external_signer.go
+++ b/external_signer.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/NethermindEth/juno/core/felt"
 )
@@ -36,6 +38,11 @@ func signTxHash(hash *felt.Felt, externalSignerUrl string) (*SignResponse, error
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
+	}
+
+	// Check if status code indicates an error (non-2xx)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Server error %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var signResp SignResponse

--- a/external_signer.go
+++ b/external_signer.go
@@ -11,7 +11,7 @@ import (
 )
 
 type SignRequest struct {
-	Hash felt.Felt `json:"hash"`
+	Hash string `json:"hash"`
 }
 
 type SignResponse struct {
@@ -20,7 +20,7 @@ type SignResponse struct {
 
 func signTxHash(hash *felt.Felt, externalSignerUrl string) (*SignResponse, error) {
 	// Create request body
-	reqBody := SignRequest{Hash: *hash}
+	reqBody := SignRequest{Hash: hash.String()}
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, err

--- a/external_signer.go
+++ b/external_signer.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -38,14 +37,12 @@ func signTxHash(hash *felt.Felt, externalSignerUrl string) (*SignResponse, error
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println("--- body", string(body))
 
 	var signResp SignResponse
 	err = json.Unmarshal(body, &signResp)
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println("--- signResp", signResp)
 
 	return &signResp, nil
 }

--- a/external_signer.go
+++ b/external_signer.go
@@ -27,7 +27,7 @@ func signTxHash(hash *felt.Felt, externalSignerUrl string) (*SignResponse, error
 	}
 
 	// Make POST request
-	resp, err := http.Post(externalSignerUrl, "application/json", bytes.NewBuffer(jsonData))
+	resp, err := http.Post(externalSignerUrl+"/sign_hash", "application/json", bytes.NewBuffer(jsonData))
 	if err != nil {
 		return nil, err
 	}

--- a/external_signer.go
+++ b/external_signer.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/NethermindEth/juno/core/felt"
+)
+
+type SignRequest struct {
+	Hash felt.Felt `json:"hash"`
+}
+
+type SignResponse struct {
+	Signature []*felt.Felt `json:"signature"`
+}
+
+func signTxHash(hash *felt.Felt, externalSignerUrl string) (*SignResponse, error) {
+	// Create request body
+	reqBody := SignRequest{Hash: *hash}
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// Make POST request
+	resp, err := http.Post(externalSignerUrl, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Read and decode response
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println("--- body", string(body))
+
+	var signResp SignResponse
+	err = json.Unmarshal(body, &signResp)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println("--- signResp", signResp)
+
+	return &signResp, nil
+}

--- a/external_signer_test.go
+++ b/external_signer_test.go
@@ -1,0 +1,82 @@
+package main_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/juno/utils"
+	main "github.com/NethermindEth/starknet-staking-v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignTxHash(t *testing.T) {
+	t.Run("Error making request", func(t *testing.T) {
+		hashToSign := utils.HexToFelt(t, "0x123")
+		externalSignerUrl := "http://localhost:1234"
+
+		res, err := main.SignTxHash(hashToSign, externalSignerUrl)
+
+		require.Nil(t, res)
+		require.ErrorContains(t, err, "connection refused")
+	})
+
+	t.Run("Request succeeded but server internal error", func(t *testing.T) {
+		serverError := "some internal error"
+
+		// Create a mock server
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Simulate API response
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(serverError))
+		}))
+		defer mockServer.Close()
+
+		hashToSign := utils.HexToFelt(t, "0x123")
+		res, err := main.SignTxHash(hashToSign, mockServer.URL)
+
+		require.Nil(t, res)
+		expectedErrorMsg := fmt.Sprintf("Server error %d: %s", http.StatusInternalServerError, serverError)
+		require.EqualError(t, err, expectedErrorMsg)
+	})
+
+	t.Run("Request succeeded but error when decoding response body", func(t *testing.T) {
+		// Create a mock server
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Simulate API response
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("not a valid marshalled SignResponse object"))
+		}))
+		defer mockServer.Close()
+
+		hashToSign := utils.HexToFelt(t, "0x123")
+		res, err := main.SignTxHash(hashToSign, mockServer.URL)
+
+		require.Nil(t, res)
+		require.ErrorContains(t, err, "invalid character")
+	})
+
+	t.Run("Successful request and response", func(t *testing.T) {
+		// Create a mock server
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Simulate API response
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"signature": ["0x123", "0x456"]}`))
+		}))
+		defer mockServer.Close()
+
+		hashToSign := utils.HexToFelt(t, "0x123")
+		res, err := main.SignTxHash(hashToSign, mockServer.URL)
+
+		expectedResult := &main.SignResponse{
+			Signature: []*felt.Felt{
+				utils.HexToFelt(t, "0x123"),
+				utils.HexToFelt(t, "0x456"),
+			},
+		}
+		require.Equal(t, expectedResult, res)
+		require.Nil(t, err)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/NethermindEth/juno v0.12.2
-	github.com/NethermindEth/starknet.go v0.8.0
+	github.com/NethermindEth/starknet.go v0.8.1
 	github.com/joho/godotenv v1.5.1
 	github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/NethermindEth/juno v0.12.2 h1:GnQUgqMCA93EO7KROlXI5AdXQ9IBvcDP2PEYFr3
 github.com/NethermindEth/juno v0.12.2/go.mod h1:PlxXUUGgzFVRIiSDrLo/jrEtAPUIHpFAylChtoH3wK4=
 github.com/NethermindEth/starknet.go v0.8.0 h1:mGh7qDWrvuXJPcgGJP31DpifzP6+Ef2gt/BQhaqsV40=
 github.com/NethermindEth/starknet.go v0.8.0/go.mod h1:slNA8PxtxA/0LQv0FwHnL3lHFDNhVZfTK6U2gjVb7l8=
+github.com/NethermindEth/starknet.go v0.8.1 h1:kJbjakN/8AlheWxpRw5vYGd971ghCa5tPqwMb54W2Ws=
+github.com/NethermindEth/starknet.go v0.8.1/go.mod h1:feelkxsialS7l6NuDAEM7sk4rsI07rmk9xyOHYVuLJQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bits-and-blooms/bitset v1.21.0 h1:9RlxRbMI5dRNNburKqfDSiz5POfImKgtablyV01WUw0=

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func LoadConfig(filePath string) (Config, error) {
 	return config, nil
 }
 
-func verifyLoadedConfig(config Config, useLocalSigner bool, useExternalSigner bool) error {
+func VerifyLoadedConfig(config Config, useLocalSigner bool, useExternalSigner bool) error {
 	if config.HttpProviderUrl == "" {
 		return missingConfigGeneralField("httpProviderUrl")
 	}
@@ -52,7 +52,7 @@ func verifyLoadedConfig(config Config, useLocalSigner bool, useExternalSigner bo
 		return missingConfigGeneralField("wsProviderUrl")
 	}
 
-	if config.OperationalAddress == (Address)(felt.Zero) {
+	if config.OperationalAddress == Address(felt.Zero) {
 		return missingConfigGeneralField("operationalAddress")
 	}
 
@@ -85,7 +85,7 @@ func NewCommand() cobra.Command {
 			return err
 		}
 
-		if err := verifyLoadedConfig(loadedConfig, useLocalSigner, useExternalSigner); err != nil {
+		if err := VerifyLoadedConfig(loadedConfig, useLocalSigner, useExternalSigner); err != nil {
 			return err
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -88,6 +89,99 @@ func writeMockConfigToTemporaryFile(t *testing.T, config main.Config) string {
 	return tmpFile.Name()
 }
 
+func TestVerifyLoadedConfig(t *testing.T) {
+	t.Run("Missing httpProviderUrl", func(t *testing.T) {
+		config := main.Config{
+			WsProviderUrl:     "ws://localhost:1235",
+			ExternalSignerUrl: "http://localhost:5678",
+			AccountData: main.AccountData{
+				PrivKey:            "0x123",
+				OperationalAddress: main.AddressFromString("0x456"),
+			},
+		}
+
+		err := main.VerifyLoadedConfig(config, true, false)
+
+		require.Equal(t, errors.New("you must specify the httpProviderUrl field in the config.json"), err)
+	})
+
+	t.Run("Missing wsProviderUrl", func(t *testing.T) {
+		config := main.Config{
+			HttpProviderUrl:   "http://localhost:1234",
+			ExternalSignerUrl: "http://localhost:5678",
+			AccountData: main.AccountData{
+				PrivKey:            "0x123",
+				OperationalAddress: main.AddressFromString("0x456"),
+			},
+		}
+
+		err := main.VerifyLoadedConfig(config, true, false)
+
+		require.Equal(t, errors.New("you must specify the wsProviderUrl field in the config.json"), err)
+	})
+
+	t.Run("Missing operationalAddress", func(t *testing.T) {
+		config := main.Config{
+			HttpProviderUrl:   "http://localhost:1234",
+			WsProviderUrl:     "ws://localhost:1235",
+			ExternalSignerUrl: "http://localhost:5678",
+			AccountData: main.AccountData{
+				PrivKey: "0x123",
+			},
+		}
+
+		err := main.VerifyLoadedConfig(config, true, false)
+
+		require.Equal(t, errors.New("you must specify the operationalAddress field in the config.json"), err)
+	})
+
+	t.Run("Both local and external signer flags are used", func(t *testing.T) {
+		config := main.Config{
+			HttpProviderUrl:   "http://localhost:1234",
+			WsProviderUrl:     "ws://localhost:1235",
+			ExternalSignerUrl: "http://localhost:5678",
+			AccountData: main.AccountData{
+				PrivKey:            "0x123",
+				OperationalAddress: main.AddressFromString("0x456"),
+			},
+		}
+
+		err := main.VerifyLoadedConfig(config, true, true)
+
+		require.Equal(t, errors.New("you must specify exactly one of --local-signer or --external-signer"), err)
+	})
+
+	t.Run("Local signer flag is used but no private key is specified", func(t *testing.T) {
+		config := main.Config{
+			HttpProviderUrl:   "http://localhost:1234",
+			WsProviderUrl:     "ws://localhost:1235",
+			ExternalSignerUrl: "http://localhost:5678",
+			AccountData: main.AccountData{
+				OperationalAddress: main.AddressFromString("0x456"),
+			},
+		}
+
+		err := main.VerifyLoadedConfig(config, true, false)
+
+		require.Equal(t, errors.New("you must specify the privateKey field in the config.json when using --local-signer flag"), err)
+	})
+
+	t.Run("External signer flag is used but no external signer URL is specified", func(t *testing.T) {
+		config := main.Config{
+			HttpProviderUrl: "http://localhost:1234",
+			WsProviderUrl:   "ws://localhost:1235",
+			AccountData: main.AccountData{
+				PrivKey:            "0x123",
+				OperationalAddress: main.AddressFromString("0x456"),
+			},
+		}
+
+		err := main.VerifyLoadedConfig(config, false, true)
+
+		require.Equal(t, errors.New("you must specify the externalSignerUrl field in the config.json when using --external-signer flag"), err)
+	})
+}
+
 func TestNewCommand(t *testing.T) {
 	t.Run("Command contains expected fields", func(t *testing.T) {
 		command := main.NewCommand()
@@ -103,7 +197,7 @@ func TestNewCommand(t *testing.T) {
 		require.Equal(t, `unknown command "config" for "starknet-staking-v2"`, err.Error())
 	})
 
-	t.Run("PreRunE returns an error", func(t *testing.T) {
+	t.Run("PreRunE returns an error: cannot load config", func(t *testing.T) {
 		command := main.NewCommand()
 
 		command.SetArgs([]string{"--config", "some inexisting file name"})
@@ -122,6 +216,39 @@ func TestNewCommand(t *testing.T) {
 
 		err = command.ExecuteContext(context.Background())
 		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("PreRunE returns an error: config verification fails", func(t *testing.T) {
+		command := main.NewCommand()
+
+		mockedConfig := main.Config{
+			HttpProviderUrl: "http://localhost:1234",
+			WsProviderUrl:   "ws://localhost:1235",
+			AccountData: main.AccountData{
+				OperationalAddress: main.AddressFromString("0x456"),
+			},
+		}
+		tmpFilePath := writeMockConfigToTemporaryFile(t, mockedConfig)
+
+		// Remove temporary file at the end of test
+		defer os.Remove(tmpFilePath)
+
+		command.SetArgs([]string{"--config", tmpFilePath, "--external-signer"})
+
+		// Not ideal but a temporary file where to redirect stderr to avoid polluting the console with unwanted cli prints
+		tmpFile, err := os.CreateTemp("", "test_output_")
+		require.NoError(t, err)
+
+		originalStderr := os.Stderr
+		// Redirect stderr to the temporary file
+		os.Stderr = tmpFile
+
+		defer tmpFile.Close()
+		defer os.Remove(tmpFile.Name())
+		defer func() { os.Stderr = originalStderr }()
+
+		err = command.ExecuteContext(context.Background())
+		require.Equal(t, errors.New("you must specify the externalSignerUrl field in the config.json when using --external-signer flag"), err)
 	})
 
 	t.Run("Full command setup works", func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -49,11 +49,12 @@ func TestLoadConfig(t *testing.T) {
 
 	t.Run("Successfully load config", func(t *testing.T) {
 		mockedConfig := main.Config{
-			HttpProviderUrl: "http://localhost:1234",
-			WsProviderUrl:   "ws://localhost:1235",
+			HttpProviderUrl:   "http://localhost:1234",
+			WsProviderUrl:     "ws://localhost:1235",
+			ExternalSignerUrl: "http://localhost:5678",
 			AccountData: main.AccountData{
 				PrivKey:            "0x123",
-				OperationalAddress: "0x456",
+				OperationalAddress: main.AddressFromString("0x456"),
 			},
 		}
 
@@ -131,7 +132,7 @@ func TestNewCommand(t *testing.T) {
 			WsProviderUrl:   "ws://localhost:1235",
 			AccountData: main.AccountData{
 				PrivKey:            "0x123",
-				OperationalAddress: "0x456",
+				OperationalAddress: main.AddressFromString("0x456"),
 			},
 		}
 		tmpFilePath := writeMockConfigToTemporaryFile(t, mockedConfig)
@@ -139,7 +140,7 @@ func TestNewCommand(t *testing.T) {
 		// Remove temporary file at the end of test
 		defer os.Remove(tmpFilePath)
 
-		command.SetArgs([]string{"--config", tmpFilePath})
+		command.SetArgs([]string{"--config", tmpFilePath, "--local-signer"})
 
 		// Not ideal but a temporary file where to redirect stderr to avoid polluting the console with unwanted cli prints
 		tmpFile, err := os.CreateTemp("", "test_output_")

--- a/provider_interaction_test.go
+++ b/provider_interaction_test.go
@@ -77,13 +77,8 @@ func TestBlockHeaderSubscription(t *testing.T) {
 	// Cannot test error when subscribing to new block headers
 
 	envVars, err := loadEnv(t)
-	loadedEnvVars := err == nil
-	if loadedEnvVars {
+	if loadedEnvVars := err == nil; loadedEnvVars {
 		t.Run("Successfully subscribing to new block headers", func(t *testing.T) {
-			// This test is failing because starknet.go does not support SW rpc v0.8.1 specs!
-			// Remove skip once it does
-			t.Skip()
-
 			wsProvider, headerChannel, err := main.BlockHeaderSubscription(envVars.wsProviderUrl, logger)
 
 			require.NotNil(t, wsProvider)

--- a/provider_interaction_test.go
+++ b/provider_interaction_test.go
@@ -70,6 +70,9 @@ func TestBlockHeaderSubscription(t *testing.T) {
 	// Cannot test error when subscribing to new block headers
 
 	t.Run("Successfully subscribing to new block headers", func(t *testing.T) {
+		// This test is failing because starknet.go does not support SW rpc v0.8.1 specs!
+		// Remove skip once it does
+		t.Skip()
 		envVars := loadEnv(t)
 
 		mockLogger.EXPECT().Infow("Successfully subscribed to new block headers", "Subscription ID", gomock.Any())

--- a/types.go
+++ b/types.go
@@ -31,6 +31,10 @@ func (a *Address) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (a Address) MarshalJSON() ([]byte, error) {
+	return (*felt.Felt)(&a).MarshalJSON()
+}
+
 type Balance felt.Felt
 
 type BlockNumber uint64

--- a/types.go
+++ b/types.go
@@ -22,6 +22,15 @@ func AddressFromString(addrStr string) Address {
 	return Address(*adr)
 }
 
+func (a *Address) UnmarshalJSON(data []byte) error {
+	var f felt.Felt
+	if err := f.UnmarshalJSON(data); err != nil {
+		return err
+	}
+	*a = Address(f)
+	return nil
+}
+
 type Balance felt.Felt
 
 type BlockNumber uint64

--- a/validator.go
+++ b/validator.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 
 	"github.com/NethermindEth/juno/core/felt"
@@ -116,7 +115,6 @@ func (s *ExternalSigner) BuildAndSendInvokeTxn(
 	functionCalls []rpc.InvokeFunctionCall,
 	multiplier float64,
 ) (*rpc.AddInvokeTransactionResponse, error) {
-	fmt.Println("--- In external signer build and send invoke txn ---")
 	nonce, err := s.Nonce(ctx, rpc.WithBlockTag("pending"), s.Address())
 	if err != nil {
 		return nil, err
@@ -159,12 +157,10 @@ func signInvokeTx(invokeTxnV3 *rpc.InvokeTxnV3, chainId *felt.Felt, externalSign
 		return err
 	}
 
-	fmt.Println("tx hash: ", hash)
 	signResp, err := signTxHash(hash, externalSignerUrl)
 	if err != nil {
 		return err
 	}
-	fmt.Println("--- signResp", signResp)
 
 	invokeTxnV3.Signature = signResp.Signature
 	return nil

--- a/validator.go
+++ b/validator.go
@@ -125,7 +125,7 @@ func (s *ExternalSigner) BuildAndSendInvokeTxn(
 
 	// Building and signing the txn, as it needs a signature to estimate the fee
 	broadcastInvokeTxnV3 := utils.BuildInvokeTxn(s.Address(), nonce, formattedCallData, makeResourceBoundsMapWithZeroValues())
-	if err := signInvokeTx(&broadcastInvokeTxnV3.InvokeTxnV3, &s.chainId, s.externalSignerUrl); err != nil {
+	if err := SignInvokeTx(&broadcastInvokeTxnV3.InvokeTxnV3, &s.ChainId, s.ExternalSignerUrl); err != nil {
 		return nil, err
 	}
 
@@ -139,7 +139,7 @@ func (s *ExternalSigner) BuildAndSendInvokeTxn(
 	broadcastInvokeTxnV3.ResourceBounds = utils.FeeEstToResBoundsMap(txnFee, multiplier)
 
 	// Signing the txn again with the estimated fee, as the fee value is used in the txn hash calculation
-	if err := signInvokeTx(&broadcastInvokeTxnV3.InvokeTxnV3, &s.chainId, s.externalSignerUrl); err != nil {
+	if err := SignInvokeTx(&broadcastInvokeTxnV3.InvokeTxnV3, &s.ChainId, s.ExternalSignerUrl); err != nil {
 		return nil, err
 	}
 
@@ -151,7 +151,7 @@ func (s *ExternalSigner) BuildAndSendInvokeTxn(
 	return txRes, nil
 }
 
-func signInvokeTx(invokeTxnV3 *rpc.InvokeTxnV3, chainId *felt.Felt, externalSignerUrl string) error {
+func SignInvokeTx(invokeTxnV3 *rpc.InvokeTxnV3, chainId *felt.Felt, externalSignerUrl string) error {
 	hash, err := hash.TransactionHashInvokeV3(invokeTxnV3, chainId)
 	if err != nil {
 		return err

--- a/validator.go
+++ b/validator.go
@@ -122,10 +122,11 @@ func (s *ExternalSigner) BuildAndSendInvokeTxn(
 		return nil, err
 	}
 
-	call := functionCalls[0]
+	fnCallData := utils.InvokeFuncCallsToFunctionCalls(functionCalls)
+	formattedCallData := account.FmtCallDataCairo2(fnCallData)
 
 	// Building and signing the txn, as it needs a signature to estimate the fee
-	broadcastInvokeTxnV3 := utils.BuildInvokeTxn(s.Address(), nonce, call.CallData, makeResourceBoundsMapWithZeroValues())
+	broadcastInvokeTxnV3 := utils.BuildInvokeTxn(s.Address(), nonce, formattedCallData, makeResourceBoundsMapWithZeroValues())
 	if err := signInvokeTx(&broadcastInvokeTxnV3.InvokeTxnV3, &s.chainId, s.externalSignerUrl); err != nil {
 		return nil, err
 	}

--- a/validator.go
+++ b/validator.go
@@ -85,12 +85,12 @@ func (v *ValidatorAccount) Address() *felt.Felt {
 
 type ExternalSigner struct {
 	*rpc.Provider
-	operationalAddress Address
-	externalSignerUrl  string
-	chainId            felt.Felt
+	OperationalAddress Address
+	ExternalSignerUrl  string
+	ChainId            felt.Felt
 }
 
-func newExternalSigner(provider *rpc.Provider, operationalAddress Address, externalSignerUrl string) (ExternalSigner, error) {
+func NewExternalSigner(provider *rpc.Provider, operationalAddress Address, externalSignerUrl string) (ExternalSigner, error) {
 	chainID, err := provider.ChainID(context.Background())
 	if err != nil {
 		return ExternalSigner{}, err
@@ -99,14 +99,14 @@ func newExternalSigner(provider *rpc.Provider, operationalAddress Address, exter
 
 	return ExternalSigner{
 		Provider:           provider,
-		operationalAddress: operationalAddress,
-		externalSignerUrl:  externalSignerUrl,
-		chainId:            *chainId,
+		OperationalAddress: operationalAddress,
+		ExternalSignerUrl:  externalSignerUrl,
+		ChainId:            *chainId,
 	}, nil
 }
 
 func (s *ExternalSigner) Address() *felt.Felt {
-	addrFelt := s.operationalAddress.ToFelt()
+	addrFelt := s.OperationalAddress.ToFelt()
 	return &addrFelt
 }
 

--- a/validator.go
+++ b/validator.go
@@ -157,7 +157,7 @@ func SignInvokeTx(invokeTxnV3 *rpc.InvokeTxnV3, chainId *felt.Felt, externalSign
 		return err
 	}
 
-	signResp, err := signTxHash(hash, externalSignerUrl)
+	signResp, err := SignTxHash(hash, externalSignerUrl)
 	if err != nil {
 		return err
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -156,6 +156,22 @@ func TestNewExternalSigner(t *testing.T) {
 		require.Nil(t, err)
 	})
 }
+
+func TestExternalSignerAddress(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	t.Run("Return signer address", func(t *testing.T) {
+		address := "0x123"
+		externalSigner := main.ExternalSigner{
+			OperationalAddress: main.AddressFromString(address),
+		}
+
+		addrFelt := externalSigner.Address()
+
+		require.Equal(t, address, addrFelt.String())
+	})
+}
 func TestFetchEpochInfo(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	t.Cleanup(mockCtrl.Finish)

--- a/validator_test.go
+++ b/validator_test.go
@@ -29,7 +29,7 @@ type envVariable struct {
 func NewAccountData(privKey string, address string) main.AccountData {
 	return main.AccountData{
 		PrivKey:            privKey,
-		OperationalAddress: address,
+		OperationalAddress: main.AddressFromString(address),
 	}
 }
 
@@ -82,8 +82,7 @@ func TestNewValidatorAccount(t *testing.T) {
 		validatorAccount, err := main.NewValidatorAccount(provider, mockLogger, &accountData)
 
 		require.Equal(t, main.ValidatorAccount{}, validatorAccount)
-		expectedErrorMsg := `Cannot create validator account: -32603 The error is not a valid RPC error: Post "http://localhost:1234": dial tcp 127.0.0.1:1234: connect: connection refused`
-		require.Equal(t, expectedErrorMsg, err.Error())
+		require.ErrorContains(t, err, "Cannot create validator account:")
 	})
 
 	t.Run("Successful account creation", func(t *testing.T) {
@@ -95,8 +94,6 @@ func TestNewValidatorAccount(t *testing.T) {
 		privateKey := "0x123"
 		address := "0x456"
 		accountData := NewAccountData(privateKey, address)
-
-		mockLogger.EXPECT().Infow("Successfully created validator account", "address", address)
 
 		mockLogger.EXPECT().Infow("Successfully created validator account", "address", address)
 


### PR DESCRIPTION
Allows user to choose between local signer or external signer by adding either the flag `--local-signer` or `--external-signer`

Note: Sometimes i used actual (read only) calls to rpc (with valid/working url in .env), and in my last tests i used httptest for mocking easily returned values allowing me to test edge cases. Idk if it's okay to have both approaches or if we wanna keep only one. I guess whatever we choose, we can update the tests in another PR as this one is a bit urgent i think.