### PR TITLE
feat(release): Add GoReleaser workflow for automated releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,86 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: validator
+    main: .
+    binary: validator
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+
+archives:
+  - formats: [tar.gz]
+    name_template: >-
+      starknet-staking-v2_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: 'checksums.txt'
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+
+dockers:
+  - image_templates:
+      - "nethermind/starknet-staking-v2:{{ .Version }}-amd64"
+    use: buildx
+    dockerfile: goreleaser.dockerfile
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "nethermind/starknet-staking-v2:{{ .Version }}-arm64"
+    use: buildx
+    dockerfile: goreleaser.dockerfile
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+    goarch: arm64
+
+docker_manifests:
+  - name_template: "nethermind/starknet-staking-v2:{{ .Version }}"
+    image_templates:
+      - "nethermind/starknet-staking-v2:{{ .Version }}-amd64"
+      - "nethermind/starknet-staking-v2:{{ .Version }}-arm64"
+
+  - name_template: "nethermind/starknet-staking-v2:latest"
+    image_templates:
+      - "nethermind/starknet-staking-v2:{{ .Version }}-amd64"
+      - "nethermind/starknet-staking-v2:{{ .Version }}-arm64"
+
+release:
+  github:
+    owner: NethermindEth
+    name: starknet-staking-v2
+  prerelease: auto
+  draft: true
+  footer: |-
+    ## Docker Images
+
+    - `nethermind/starknet-staking-v2:{{ .Version }}`
+    - `nethermind/starknet-staking-v2:latest`
+
+    ---

--- a/goreleaser.dockerfile
+++ b/goreleaser.dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+WORKDIR /app
+
+RUN mkdir -p /app/config && chown appuser:appgroup /app/config
+
+COPY --chown=appuser:appgroup validator /app/validator
+
+USER appuser
+
+ENTRYPOINT ["/app/validator"]


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow and GoReleaser configuration to automate the release process.

- Builds binaries for Linux and Darwin (amd64/arm64).
- Creates multi-architecture Docker images (linux/amd64, linux/arm64) pushed to Docker Hub under version and latest tags.
- Generates checksums and archives.
- Creates a draft GitHub release upon tagging a version (v*).

Sample workflow: https://github.com/NethermindEth/starknet-staking-v2/actions/runs/14378321797/job/40315932762
Sample release: https://github.com/NethermindEth/starknet-staking-v2/releases/tag/untagged-f9efd986265141de8eba
Sample docker images: https://hub.docker.com/r/nethermind/starknet-staking-v2/tags