### PR TITLE
fix: correct error message for private key conversion

### DIFF
--- a/validator/validator.go
+++ b/validator/validator.go
@@ -42,7 +42,7 @@ func NewInternalSigner[Log Logger](
 	// todo(rdr): do we need to check the private key has maximum size
 	privateKey, ok := new(big.Int).SetString(signer.PrivKey, 0)
 	if !ok {
-		return InternalSigner{}, errors.Errorf("private key %s into a big int", privateKey)
+		return InternalSigner{}, errors.Errorf("Cannot turn private key %s into a big int", privateKey)
 	}
 
 	publicKey, _, err := curve.Curve.PrivateToPoint(privateKey)


### PR DESCRIPTION
Update error message in NewInternalSigner **to match test expectations** and improve clarity.