### PR TITLE
feat: update the code to make the metric server optional

### DIFF
--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -30,7 +30,9 @@ func NewCommand() cobra.Command {
 	var configPath string
 	var logLevelF string
 	var maxRetriesF string
-	var metricsAddressF string
+	var metricsF bool
+	var metricsHostF string
+	var metricsPortF string
 
 	var config configP.Config
 	var maxRetries types.Retries
@@ -78,29 +80,53 @@ func NewCommand() cobra.Command {
 	}
 
 	run := func(cmd *cobra.Command, args []string) {
+		v, err := validator.New(&config, &snConfig, logger)
+		if err != nil {
+			logger.Errorf("cannot start validator: %s", err.Error())
+			return
+		}
+
 		fmt.Printf(greeting, validator.Version)
 
-		// Create metrics server
-		metricsServer := metrics.NewMetrics(&logger, metricsAddressF)
+		globalCtx := context.Background()
+		var tracer metrics.Tracer = metrics.NewNoOpMetrics()
+		if metricsF {
+			// Create metrics server
+			address := fmt.Sprintf("%s:%s", metricsHostF, metricsPortF)
+			metrics := metrics.NewMetrics(address, v.ChainID(), &logger)
+			tracer = metrics
 
-		// Setup signal handling for graceful shutdown
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+			// Setup signal handling for graceful shutdown
+			ctx, cancel := context.WithCancel(context.Background())
+			globalCtx = ctx
+			defer cancel()
+
+			// Start metrics server in a goroutine
+			go func() {
+				if err := metrics.Start(); err != nil {
+					logger.Errorw("Failed to start metrics server", "error", err)
+				}
+			}()
+			// Graceful shutdown at the end
+			defer func() {
+				shutdownCtx, shutdownCancel := context.WithTimeout(
+					context.Background(), 5*time.Second,
+				)
+				defer shutdownCancel()
+				if err := metrics.Stop(shutdownCtx); err != nil {
+					logger.Errorw("Failed to stop metrics server", "error", err)
+				}
+			}()
+		}
 
 		signalCh := make(chan os.Signal, 1)
 		signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)
 
-		// Start metrics server in a goroutine
-		go func() {
-			if err := metricsServer.Start(); err != nil {
-				logger.Errorw("Failed to start metrics server", "error", err)
-			}
-		}()
-
 		// Start validator in a goroutine
 		errCh := make(chan error, 1)
 		go func() {
-			if err := validator.Attest(ctx, &config, &snConfig, maxRetries, logger, metricsServer); err != nil {
+			err := v.Attest(globalCtx, maxRetries, tracer)
+			if err != nil {
 				logger.Error(err)
 				errCh <- err
 			}
@@ -114,13 +140,6 @@ func NewCommand() cobra.Command {
 			logger.Errorw("Validator stopped with error", "error", err)
 		}
 
-		// Graceful shutdown
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer shutdownCancel()
-
-		if err := metricsServer.Stop(shutdownCtx); err != nil {
-			logger.Errorw("Failed to stop metrics server", "error", err)
-		}
 	}
 
 	cmd := cobra.Command{
@@ -169,16 +188,12 @@ func NewCommand() cobra.Command {
 		"",
 		"Staking contract address. Defaults values are provided for Sepolia and Mainnet",
 	)
-	// Disabled for now
-	// cmd.Flags().StringVar(
-	// 	&snConfig.AttestOptions,
-	// 	"attest-fee",
-	// 	"once",
-	// 	"This flag determines the fee to pay for each attest transaction."+
-	// 		" It can be either a positive number or one of the follwing options:\n"+
-	// 		" - \"once\": attest fee is estimated once and successive calls use that value.\n"+
-	// 		" - \"always\": an estimate fee call is done before submitting each attestation.",
-	// )
+
+	// Metrick trackng flags
+	cmd.Flags().BoolVar(&metricsF, "metrics", false, "Enable metric tracking via Prometheus")
+	cmd.Flags().StringVar(&metricsHostF, "metrics-host", "localhost", "Host for the metric server")
+	cmd.Flags().StringVar(&metricsPortF, "metrics-port", "9090", "Port for the metric server")
+
 	// Other flags
 	cmd.Flags().StringVar(
 		&maxRetriesF,
@@ -189,9 +204,6 @@ func NewCommand() cobra.Command {
 	)
 	cmd.Flags().StringVar(
 		&logLevelF, "log-level", utils.INFO.String(), "Options: trace, debug, info, warn, error.",
-	)
-	cmd.Flags().StringVar(
-		&metricsAddressF, "metrics-address", ":9090", "Address and port for the metrics server (e.g., :9090)",
 	)
 
 	return cmd

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -103,7 +103,7 @@ func NewCommand() cobra.Command {
 
 			// Start metrics server in a goroutine
 			go func() {
-				if err := metrics.Start(); err != nil {
+				if err := metrics.Start(); err != nil && err.Error() != "http: Server closed" {
 					logger.Errorw("Failed to start metrics server", "error", err)
 				}
 			}()
@@ -144,7 +144,7 @@ func NewCommand() cobra.Command {
 
 	cmd := cobra.Command{
 		Use:     "validator",
-		Short:   "Program for Starknet validators to attest to epochs with respect to Staking v2",
+		Short:   "Validator program for Starknet stakers created by Nethermind",
 		Version: validator.Version,
 		PreRunE: preRunE,
 		Run:     run,

--- a/validator/dispatcher.go
+++ b/validator/dispatcher.go
@@ -90,7 +90,6 @@ func (d *EventDispatcher[S]) Dispatch(signer S, logger *utils.ZapLogger, tracer 
 	for {
 		select {
 		case event, ok := <-d.AttestRequired:
-			println("b0")
 			if !ok {
 				return
 			}
@@ -111,10 +110,8 @@ func (d *EventDispatcher[S]) Dispatch(signer S, logger *utils.ZapLogger, tracer 
 
 			logger.Infow("Invoking attest", "block hash", event.BlockHash.String())
 
-			println("b1")
 			resp, err := signerP.InvokeAttest(signer, &event)
 			if err != nil {
-				println("b1e")
 				logger.Errorw(
 					"Failed to attest", "block hash", event.BlockHash.String(), "error", err,
 				)
@@ -138,17 +135,12 @@ func (d *EventDispatcher[S]) Dispatch(signer S, logger *utils.ZapLogger, tracer 
 				continue
 			}
 
-			println("b2")
-
 			// Record attestation submission in metrics
 			tracer.RecordAttestationSubmitted()
-			println("b3")
 
 			logger.Debugw("Attest transaction sent", "hash", resp.TransactionHash)
 			d.CurrentAttest.setTransactionHash(resp.TransactionHash)
-			println("b4")
 		case <-d.EndOfWindow:
-			println("c1")
 			logger.Info("End of window reached")
 
 			if d.CurrentAttest.Status != Successful {

--- a/validator/dispatcher.go
+++ b/validator/dispatcher.go
@@ -117,7 +117,7 @@ func (d *EventDispatcher[S]) Dispatch(signer S, logger *utils.ZapLogger, tracer 
 				)
 
 				if strings.Contains(err.Error(), "Attestation is done for this epoch") {
-					metricsServer.RecordAttestationConfirmed(ChainID)
+					tracer.RecordAttestationConfirmed()
 					logger.Infow(
 						"Attestation is done for this epoch",
 						"block hash", event.BlockHash.String(),

--- a/validator/dispatcher_test.go
+++ b/validator/dispatcher_test.go
@@ -31,12 +31,10 @@ func TestDispatch(t *testing.T) {
 	validationContracts := types.ValidationContractsFromAddresses(contractAddresses)
 
 	t.Run("Simple scenario: only 1 attest that succeeds", func(t *testing.T) {
-		println("a0")
 		// Setup
 		dispatcher := validator.NewEventDispatcher[*mocks.MockSigner]()
 		blockHashFelt := new(felt.Felt).SetUint64(1)
 
-		println("a1")
 		attestAddr := validationContracts.Attest.Felt()
 		calls := []rpc.InvokeFunctionCall{{
 			ContractAddress: attestAddr,
@@ -54,19 +52,16 @@ func TestDispatch(t *testing.T) {
 			validator.SepoliaValidationContracts(t),
 		).Times(1)
 
-		println("a2")
 		// Create a mock metrics server
 
 		// Start routine
 		wg := &conc.WaitGroup{}
 		wg.Go(func() { dispatcher.Dispatch(mockAccount, logger, tracer) })
 
-		println("a3")
 		// Send event
 		blockHash := validator.BlockHash(*blockHashFelt)
 		dispatcher.AttestRequired <- validator.AttestRequired{BlockHash: blockHash}
 
-		println("a3.1")
 		// Preparation for EndOfWindow event
 		mockAccount.EXPECT().
 			GetTransactionStatus(context.Background(), addTxHash).
@@ -75,15 +70,12 @@ func TestDispatch(t *testing.T) {
 				ExecutionStatus: rpc.TxnExecutionStatusSUCCEEDED,
 			}, nil)
 
-		println("a3.2")
 		// Send EndOfWindow
 		dispatcher.EndOfWindow <- struct{}{}
-		println("a4")
 
 		close(dispatcher.AttestRequired)
 		// Wait for dispatch routine to finish
 		wg.Wait()
-		println("a5")
 
 		// Assert
 		expectedAttest := validator.AttestTracker{
@@ -91,7 +83,6 @@ func TestDispatch(t *testing.T) {
 			TransactionHash: *addTxHash,
 			Status:          validator.Successful,
 		}
-		println("a6")
 		require.Equal(t, expectedAttest, dispatcher.CurrentAttest)
 	})
 

--- a/validator/metrics/metrics.go
+++ b/validator/metrics/metrics.go
@@ -11,10 +11,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+var _ Tracer = (*Metrics)(nil)
+
 // Metrics represents the metrics server for the validator
 type Metrics struct {
 	server                          *http.Server
 	logger                          *utils.ZapLogger
+	network                         string
 	registry                        *prometheus.Registry
 	latestBlockNumber               *prometheus.GaugeVec
 	currentEpochID                  *prometheus.GaugeVec
@@ -28,11 +31,12 @@ type Metrics struct {
 }
 
 // NewMetrics creates a new metrics server
-func NewMetrics(logger *utils.ZapLogger, address string) *Metrics {
+func NewMetrics(serverAddress string, chainID string, logger *utils.ZapLogger) *Metrics {
 	registry := prometheus.NewRegistry()
 
 	m := &Metrics{
 		logger:   logger,
+		network:  chainID,
 		registry: registry,
 		latestBlockNumber: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -124,101 +128,9 @@ func NewMetrics(logger *utils.ZapLogger, address string) *Metrics {
 	mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 
 	m.server = &http.Server{
-		Addr:    address,
+		Addr:    serverAddress,
 		Handler: mux,
 	}
-
-	return m
-}
-
-// NewMockMetricsForTest creates a new metrics server for testing purposes
-// It doesn't start an HTTP server but provides all the necessary methods for testing
-func NewMockMetricsForTest(logger *utils.ZapLogger) *Metrics {
-	registry := prometheus.NewRegistry()
-
-	m := &Metrics{
-		logger:   logger,
-		registry: registry,
-		latestBlockNumber: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "validator_attestation_starknet_latest_block_number",
-				Help: "The latest block number seen by the validator on the Starknet network",
-			},
-			[]string{"network"},
-		),
-		currentEpochID: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "validator_attestation_current_epoch_id",
-				Help: "The ID of the current epoch the validator is participating in",
-			},
-			[]string{"network"},
-		),
-		currentEpochLength: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "validator_attestation_current_epoch_length",
-				Help: "The total length (in blocks) of the current epoch",
-			},
-			[]string{"network"},
-		),
-		currentEpochStartingBlockNumber: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "validator_attestation_current_epoch_starting_block_number",
-				Help: "The first block number of the current epoch",
-			},
-			[]string{"network"},
-		),
-		currentEpochAssignedBlockNumber: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "validator_attestation_current_epoch_assigned_block_number",
-				Help: "The specific block number within the current epoch for which the validator is assigned to attest",
-			},
-			[]string{"network"},
-		),
-		lastAttestationTimestamp: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "validator_attestation_last_attestation_timestamp_seconds",
-				Help: "The Unix timestamp (in seconds) of the last successful attestation submission",
-			},
-			[]string{"network"},
-		),
-		attestationSubmittedCount: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "validator_attestation_attestation_submitted_count",
-				Help: "The total number of attestations submitted by the validator since startup",
-			},
-			[]string{"network"},
-		),
-		attestationFailureCount: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "validator_attestation_attestation_failure_count",
-				Help: "The total number of attestation transaction submission failures encountered by the validator since startup",
-			},
-			[]string{"network"},
-		),
-		attestationConfirmedCount: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "validator_attestation_attestation_confirmed_count",
-				Help: "The total number of attestations that have been confirmed on the network since validator startup",
-			},
-			[]string{"network"},
-		),
-	}
-
-	// Register metrics with Prometheus registry
-	registry.MustRegister(
-		m.latestBlockNumber,
-		m.currentEpochID,
-		m.currentEpochLength,
-		m.currentEpochStartingBlockNumber,
-		m.currentEpochAssignedBlockNumber,
-		m.lastAttestationTimestamp,
-		m.attestationSubmittedCount,
-		m.attestationFailureCount,
-		m.attestationConfirmedCount,
-	)
-
-	// For testing, we don't create an HTTP server
-	// This allows tests to run without binding to ports
 
 	return m
 }
@@ -236,30 +148,30 @@ func (m *Metrics) Stop(ctx context.Context) error {
 }
 
 // UpdateLatestBlockNumber updates the latest block number metric
-func (m *Metrics) UpdateLatestBlockNumber(network string, blockNumber uint64) {
-	m.latestBlockNumber.WithLabelValues(network).Set(float64(blockNumber))
+func (m *Metrics) UpdateLatestBlockNumber(blockNumber uint64) {
+	m.latestBlockNumber.WithLabelValues(m.network).Set(float64(blockNumber))
 }
 
 // UpdateEpochInfo updates the epoch-related metrics
-func (m *Metrics) UpdateEpochInfo(network string, epochInfo *types.EpochInfo, targetBlock uint64) {
-	m.currentEpochID.WithLabelValues(network).Set(float64(epochInfo.EpochId))
-	m.currentEpochLength.WithLabelValues(network).Set(float64(epochInfo.EpochLen))
-	m.currentEpochStartingBlockNumber.WithLabelValues(network).Set(float64(epochInfo.CurrentEpochStartingBlock.Uint64()))
-	m.currentEpochAssignedBlockNumber.WithLabelValues(network).Set(float64(targetBlock))
+func (m *Metrics) UpdateEpochInfo(epochInfo *types.EpochInfo, targetBlock uint64) {
+	m.currentEpochID.WithLabelValues(m.network).Set(float64(epochInfo.EpochId))
+	m.currentEpochLength.WithLabelValues(m.network).Set(float64(epochInfo.EpochLen))
+	m.currentEpochStartingBlockNumber.WithLabelValues(m.network).Set(float64(epochInfo.CurrentEpochStartingBlock.Uint64()))
+	m.currentEpochAssignedBlockNumber.WithLabelValues(m.network).Set(float64(targetBlock))
 }
 
 // RecordAttestationSubmitted increments the attestation submitted counter
-func (m *Metrics) RecordAttestationSubmitted(network string) {
-	m.attestationSubmittedCount.WithLabelValues(network).Inc()
-	m.lastAttestationTimestamp.WithLabelValues(network).Set(float64(time.Now().Unix()))
+func (m *Metrics) RecordAttestationSubmitted() {
+	m.attestationSubmittedCount.WithLabelValues().Inc()
+	m.lastAttestationTimestamp.WithLabelValues(m.network).Set(float64(time.Now().Unix()))
 }
 
 // RecordAttestationFailure increments the attestation failure counter
-func (m *Metrics) RecordAttestationFailure(network string) {
-	m.attestationFailureCount.WithLabelValues(network).Inc()
+func (m *Metrics) RecordAttestationFailure() {
+	m.attestationFailureCount.WithLabelValues(m.network).Inc()
 }
 
 // RecordAttestationConfirmed increments the attestation confirmed counter
-func (m *Metrics) RecordAttestationConfirmed(network string) {
-	m.attestationConfirmedCount.WithLabelValues(network).Inc()
+func (m *Metrics) RecordAttestationConfirmed() {
+	m.attestationConfirmedCount.WithLabelValues(m.network).Inc()
 }

--- a/validator/metrics/noopmetrics.go
+++ b/validator/metrics/noopmetrics.go
@@ -1,0 +1,21 @@
+package metrics
+
+import "github.com/NethermindEth/starknet-staking-v2/validator/types"
+
+var _ Tracer = (*NoOpMetrics)(nil)
+
+type NoOpMetrics struct{}
+
+func NewNoOpMetrics() *NoOpMetrics {
+	return &NoOpMetrics{}
+}
+
+func (m *NoOpMetrics) UpdateLatestBlockNumber(blockNumber uint64) {}
+
+func (m *NoOpMetrics) UpdateEpochInfo(epochInfo *types.EpochInfo, targetBlock uint64) {}
+
+func (m *NoOpMetrics) RecordAttestationSubmitted() {}
+
+func (m *NoOpMetrics) RecordAttestationFailure() {}
+
+func (m *NoOpMetrics) RecordAttestationConfirmed() {}

--- a/validator/metrics/tracer.go
+++ b/validator/metrics/tracer.go
@@ -1,0 +1,11 @@
+package metrics
+
+import "github.com/NethermindEth/starknet-staking-v2/validator/types"
+
+type Tracer interface {
+	UpdateLatestBlockNumber(blockNumber uint64)
+	UpdateEpochInfo(epochInfo *types.EpochInfo, targetBlock uint64)
+	RecordAttestationSubmitted()
+	RecordAttestationFailure()
+	RecordAttestationConfirmed()
+}

--- a/validator/signer/types.go
+++ b/validator/signer/types.go
@@ -4,7 +4,6 @@ import "github.com/NethermindEth/starknet-staking-v2/validator/types"
 
 type (
 	Address             = types.Address
-	AttestFee           = types.AttestFee
 	AttestInfo          = types.AttestInfo
 	AttestRequired      = types.AttestRequired
 	Balance             = types.Balance

--- a/validator/types.go
+++ b/validator/types.go
@@ -4,7 +4,6 @@ import "github.com/NethermindEth/starknet-staking-v2/validator/types"
 
 type (
 	Address             = types.Address
-	AttestFee           = types.AttestFee
 	AttestInfo          = types.AttestInfo
 	AttestRequired      = types.AttestRequired
 	Balance             = types.Balance

--- a/validator/types/staking.go
+++ b/validator/types/staking.go
@@ -3,7 +3,6 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/NethermindEth/starknet-staking-v2/validator/config"
 	"lukechampine.com/uint128"
@@ -35,63 +34,6 @@ func (e *EpochInfo) String() string {
 	}
 
 	return string(jsonData)
-}
-
-type recalculate int
-
-const (
-	once recalculate = iota
-	always
-	never
-)
-
-type AttestFee struct {
-	recalculate recalculate
-	value       uint64
-}
-
-func AttestFeeFromString(attestOption string) (AttestFee, error) {
-	if attestOption == "always" {
-		return AttestFee{
-			recalculate: always,
-			value:       0,
-		}, nil
-	}
-	if attestOption == "once" {
-		return AttestFee{
-			recalculate: once,
-			value:       0,
-		}, nil
-	}
-	val, err := strconv.ParseUint(attestOption, 10, 64)
-	if err != nil {
-		return AttestFee{},
-			fmt.Errorf(
-				"cannot parse attest options :"+
-					" `%s` is not a valid number nor a valid option",
-				attestOption,
-			)
-	}
-	return AttestFee{
-		recalculate: never,
-		value:       val,
-	}, nil
-}
-
-func (a *AttestFee) Get() uint64 {
-	switch a.recalculate {
-	case always:
-		// do the recalculation
-		return 1000
-	case once:
-		// do the recalculation
-		a.recalculate = never
-		return a.value
-	case never:
-		return a.value
-	default:
-		panic("Unknown recalculate option for AttestFee")
-	}
 }
 
 type ValidationContracts struct {

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -62,7 +62,10 @@ func TestAttest(t *testing.T) {
 		logger := utils.NewNopZapLogger()
 		ctx := context.Background()
 		metricsServer := mockMetricsServer()
-		err = validator.Attest(ctx, config, sepoliaConfig, defaultRetries(t), *logger, metricsServer)
+
+		v, err := validator.New(config, sepoliaConfig, *logger)
+		require.NoError(t, err)
+		err = v.Attest(ctx, defaultRetries(t), metricsServer)
 
 		expectedErrorMsg := fmt.Sprintf(
 			"Error when calling entrypoint `get_attestation_info_by_operational_address`: -32603 The error is not a valid RPC error: %d Internal Server Error: %s",
@@ -104,7 +107,10 @@ func TestAttest(t *testing.T) {
 		logger := utils.NewNopZapLogger()
 		ctx := context.Background()
 		metricsServer := mockMetricsServer()
-		err = validator.Attest(ctx, config, sepoliaConfig, defaultRetries(t), *logger, metricsServer)
+
+		v, err := validator.New(config, sepoliaConfig, *logger)
+		require.NoError(t, err)
+		err = v.Attest(ctx, defaultRetries(t), metricsServer)
 
 		expectedErrorMsg := fmt.Sprintf(
 			"Error when calling entrypoint `get_attestation_info_by_operational_address`: -32603 The error is not a valid RPC error: %d Internal Server Error: %s",
@@ -836,5 +842,5 @@ func defaultRetries(t *testing.T) types.Retries {
 func mockMetricsServer() *metrics.Metrics {
 	// Create a mock metrics server for testing
 	logger := utils.NewNopZapLogger()
-	return metrics.NewMetrics(logger, ":9090")
+	return metrics.NewMetrics("localhost:9090", "SN_SEPOLIA", logger)
 }


### PR DESCRIPTION
- Make optional the use of a tracer server. Created NoOp Tracer.
- Refactor the Validator pkg code to have a new Validator type.
- Remove remnant codes of fixed attestation values attempt.