### PR TITLE
fix: nonce error when trying to resend the failed txn in EventDispatcher

### DIFF
--- a/validator/dispatcher.go
+++ b/validator/dispatcher.go
@@ -59,7 +59,6 @@ func (t *AttestTransaction) Invoke(signer signerP.Signer) (
 	if !t.valid {
 		return nil, errors.New("invoking attest transaction before building it")
 	}
-	t.valid = false
 
 	// todo(rdr): make sure to estimate fee with query bit with Braavos Account
 	estimate, err := signer.EstimateFee(&t.txn)
@@ -214,8 +213,8 @@ func (d *EventDispatcher[S]) Dispatch(
 				}
 				logger.Debug("built attest transaction successfully")
 			} else {
-				// Otherwise, the tx was prepared in advance. Update the transaction nonce
-				// since it was set some blocks ago
+				// Otherwise, the tx was either prepared in advance or failed, and it needs to be resend.
+				// In both cases, the transaction nonce needs to be updated.
 				logger.Debug("updating attest transaction nonce")
 				err := d.CurrentAttest.Transaction.UpdateNonce(signer)
 				if err != nil {


### PR DESCRIPTION
The validator tool is failing to resend a txn when the attestation fails, receiving the `Invalid transaction nonce` error.
This occurs due to a logic error that incorrectly marks the txn as "invalid", preventing it from having its nonce updated.

This PR removes the wrong "invalid" assignment made by the `AttestTransaction.Invoke(...)` method, allowing the failed txn to have its nonce updated in the `else` statement [here](https://github.com/NethermindEth/starknet-staking-v2/blob/bdba12658d233b93af1bb6b6de10d0335710f5eb/validator/dispatcher.go#L216). 