### PR TITLE
docs: udpate docs to use rpcv09 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Validator software written in Go for Starknet staking v2 as specified in [SNIP 2
 
 ## Requirements
 
-- A connection to a [Starknet node or RPC endpoint](https://www.starknet.io/fullnodes-rpc-services/) with support for the JSON-RPC 0.8.0 API specification. For reliability reasons we recommend stakers to host their own nodes. See [Juno](https://github.com/NethermindEth/juno) and [Pathfinder](https://github.com/eqlabs/pathfinder).
+- A connection to a [Starknet node or RPC endpoint](https://www.starknet.io/fullnodes-rpc-services/) with support for the JSON-RPC 0.9.0 API specification. For reliability reasons we recommend stakers to host their own nodes. See [Juno](https://github.com/NethermindEth/juno) and [Pathfinder](https://github.com/eqlabs/pathfinder).
 - An account with enough funds to pay for the attestation transactions.
 
 ## Installation
@@ -37,7 +37,7 @@ The validator can be run with:
 ./build/validator --config <path_to_config_file>
 ```
 
-The config file is `.json` which specifies two main fields `provider` and `signer`. For the `provider`, it requires an *http* and *websocket* endpoints to a starknet node that supports rpc version `0.8.1` or higher. Those endpoints are used to listen information from the network.
+The config file is `.json` which specifies two main fields `provider` and `signer`. For the `provider`, it requires an *http* and *websocket* endpoints to a starknet node that supports rpc version `0.9.0`. Those endpoints are used to listen information from the network.
 
 For the `signer`, you need to specify the *operational address* and a signing method. 
 The signing method can be either internal to the tool or asked externally, based on if you provide a *private key* or an external *url*:
@@ -51,8 +51,8 @@ A full configuration file looks like this:
 ```json
 {
   "provider": {
-      "http": "http://localhost:6060/v0_8",
-      "ws": "ws://localhost:6061/v0_8"
+      "http": "http://localhost:6060/v0_9",
+      "ws": "ws://localhost:6061/v0_9"
   },
   "signer": {
       "url": "http://localhost:8080",
@@ -69,8 +69,8 @@ Note that because both `url` and `privateKey` fields are set in the previous exa
 Alternatively, similarly as described as the previous section, the validator can be configured using environment vars. The following example using a `.env` file with the following content:
 
 ```bash
-export PROVIDER_HTTP_URL="http://localhost:6060/v0_8"
-export PROVIDER_WS_URL="ws://localhost:6061/v0_8"
+export PROVIDER_HTTP_URL="http://localhost:6060/v0_9"
+export PROVIDER_WS_URL="ws://localhost:6061/v0_9"
 
 export SIGNER_EXTERNAL_URL="http://localhost:8080"
 export SIGNER_OPERATIONAL_ADDRESS="0x123"
@@ -91,8 +91,8 @@ Finally, as a third alternative, you can specify the necessary validation config
 
 ```bash
 ./build/validator \
-    --provider-http "http://localhost:6060/v0_8" \
-    --provider-ws "ws://localhost:6061/v0_8" \
+    --provider-http "http://localhost:6060/v0_9" \
+    --provider-ws "ws://localhost:6061/v0_9" \
     --signer-url "http://localhost:8080" \
     --signer-op-address "0x123" \
     --signer-priv-key "0x456"
@@ -104,9 +104,9 @@ Finally, as a third alternative, you can specify the necessary validation config
 Using a combination of both approaches is also valid. Values set by flags will override values set by enviroment flags and values set by enviroment flags will override values set in a configuration file.
 
 ```bash
-PROVIDER_HTTP_URL="http://localhost:6060/v0_8" ./build/validator \
+PROVIDER_HTTP_URL="http://localhost:6060/v0_9" ./build/validator \
     --config <path_to_config_file> \
-    --provider-ws "ws://localhost:6061/v0_8" \
+    --provider-ws "ws://localhost:6061/v0_9" \
     --signer-url "http//localhost:8080" \
     --signer-op-address "0x123" \
     --private-key "0x456"

--- a/docs/docs/becoming-validator.md
+++ b/docs/docs/becoming-validator.md
@@ -9,7 +9,7 @@ Staking on Starknet provides an opportunity to contribute to network security an
 ## Prerequisites
 
 - **STRK Tokens**: At least 20,000 STRK is required for staking on mainnet (1 STRK on Sepolia testnet). For the latest details, check out the [Staking Protocol Details](https://docs.starknet.io/staking/overview/#protocol_details).
-- **Node Setup**: A connection to a [Starknet node or RPC endpoint](https://www.starknet.io/fullnodes-rpc-services/) with support for the JSON-RPC 0.8.1 API specification. For reliability reasons we recommend stakers to host their own nodes. See [Juno](https://github.com/NethermindEth/juno) and [Pathfinder](https://github.com/eqlabs/pathfinder).
+- **Node Setup**: A connection to a [Starknet node or RPC endpoint](https://www.starknet.io/fullnodes-rpc-services/) with support for the JSON-RPC 0.9.0 API specification. For reliability reasons we recommend stakers to host their own nodes. See [Juno](https://github.com/NethermindEth/juno) and [Pathfinder](https://github.com/eqlabs/pathfinder).
 - **Starknet Wallet**: A compatible wallet, like [Braavos](https://braavos.app/wallet-features/ledger-on-braavos/) or [Argent](https://www.argent.xyz/blog/how-to-use-your-hardware-wallet-with-argent).
 - **Access to CLI/Block Explorer**: Tools like [Voyager](https://voyager.online) for interacting with contracts.
 - **An account with enough funds** to pay for the attestation transactions.
@@ -39,8 +39,8 @@ The configuration file properties for internal signing will look like:
 ```json
 {
   "provider": {
-      "http": "http://localhost:6060/v0_8",
-      "ws": "ws://localhost:6061/v0_8"
+      "http": "http://localhost:6060/v0_9",
+      "ws": "ws://localhost:6061/v0_9"
   },
   "signer": {
       "operationalAddress": "your operational address",

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -20,8 +20,8 @@ The validator can be configured directly on the command line, e.g:
 
 ```bash
 docker run nethermind/starknet-staking-v2 \
-    --provider-http "http://localhost:6060/rpc/v0_8" \
-    --provider-ws "ws://localhost:6061/ws/v0_8" \
+    --provider-http "http://localhost:6060/rpc/v0_9" \
+    --provider-ws "ws://localhost:6061/ws/v0_9" \
     --signer-op-address "0x123" \
     --signer-url "http://localhost:8080"
 ```
@@ -35,8 +35,8 @@ Command line parameters override environment variables and configuration file.
 The validator can be configured through environment variables using specific variable names:
 
 ```bash
-PROVIDER_HTTP_URL="http://localhost:6060/v0_8" \
-PROVIDER_WS_URL="ws://localhost:6061/v0_8" \
+PROVIDER_HTTP_URL="http://localhost:6060/v0_9" \
+PROVIDER_WS_URL="ws://localhost:6061/v0_9" \
 SIGNER_OPERATIONAL_ADDRESS="0x123" \
 SIGNER_PRIVATE_KEY="0x456" \
 ./build/validator
@@ -47,8 +47,8 @@ SIGNER_PRIVATE_KEY="0x456" \
 Create a `.env` file with your configuration:
 
 ```bash title=".env"
-PROVIDER_HTTP_URL="http://localhost:6060/v0_8"
-PROVIDER_WS_URL="ws://localhost:6061/v0_8"
+PROVIDER_HTTP_URL="http://localhost:6060/v0_9"
+PROVIDER_WS_URL="ws://localhost:6061/v0_9"
 
 SIGNER_OPERATIONAL_ADDRESS="0x123"
 SIGNER_EXTERNAL_URL="http://localhost:8080"
@@ -67,8 +67,8 @@ When using Docker, set environment variables using the `-e` option:
 
 ```bash
 docker run \
-  -e PROVIDER_HTTP_URL="http://host.docker.internal:6060/v0_8" \
-  -e PROVIDER_WS_URL="ws://host.docker.internal:6061/v0_8" \
+  -e PROVIDER_HTTP_URL="http://host.docker.internal:6060/v0_9" \
+  -e PROVIDER_WS_URL="ws://host.docker.internal:6061/v0_9" \
   -e SIGNER_OPERATIONAL_ADDRESS="0x123" \
   -e SIGNER_EXTERNAL_URL="http://host.docker.internal:8080" \
   nethermind/starknet-staking-v2
@@ -93,8 +93,8 @@ The validator can be configured using a JSON file:
 ```json
 {
   "provider": {
-    "http": "http://localhost:6060/v0_8",
-    "ws": "ws://localhost:6061/v0_8"
+    "http": "http://localhost:6060/v0_9",
+    "ws": "ws://localhost:6061/v0_9"
   },
   "signer": {
     "operationalAddress": "0x123",
@@ -124,9 +124,9 @@ You must provide either `privateKey` for internal signing or `url` for external 
 You can combine multiple configuration methods. Values set by command line flags will override environment variables, and environment variables will override configuration file settings.
 
 ```bash
-PROVIDER_HTTP_URL="http://localhost:6060/v0_8" ./build/validator \
+PROVIDER_HTTP_URL="http://localhost:6060/v0_9" ./build/validator \
     --config config.json \
-    --provider-ws "ws://localhost:6061/v0_8" \
+    --provider-ws "ws://localhost:6061/v0_9" \
     --signer-url "http://localhost:8080" \
     --log-level debug
 ```


### PR DESCRIPTION
Updates all the examples and quotes in the main readme and the documentation to use rpcv09 instead of rpcv08, as the code base has already been updated.