### PR TITLE
fix: bump Docker builder image to Go 1.27

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -16,11 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Set up Go
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
-        with:
-          go-version: "1.25"
-
       - name: Login to Docker Hub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Builder Stage ----
-FROM golang:1.25-alpine AS builder
+FROM golang:1.27-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Fixes the Docker image build broken by #111. `go.mod` now requires Go 1.27, but the builder stage still used `golang:1.25-alpine`.

- Bump the Dockerfile builder image to `golang:1.27-alpine`.
- Remove the `Set up Go` step from `docker-image-build-push.yml`. The whole build runs inside the Docker builder stage, so the runner's Go toolchain is never used.